### PR TITLE
Use Nuxt's build instead of generate

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build site
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_NUXT_VUEFIRE_EXAMPLE_SPARK }}
-        run: pnpm run generate
+        run: pnpm run build
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build site
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_NUXT_VUEFIRE_EXAMPLE_SPARK }}
-        run: pnpm run generate
+        run: pnpm run build
 
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
Following the issue https://github.com/posva/nuxt--vuefire-example-blaze-plan/issues/2#issue-1886372988, this PR aims to change the CI/CD pipeline to use the Nuxt `build` command instead of `generate`.