### PR TITLE
fix: replace deprecated process.dev with import.meta.dev

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -44,7 +44,7 @@ watch(user, async (currentUser, previousUser) => {
     }
 
     // fallback photo for dev with emulators or anonymous users
-    if (currentUser.isAnonymous || process.dev) {
+    if (currentUser.isAnonymous || import.meta.dev) {
       userData.displayName ??= 'Anonymous'
       userData.photoURL ??= `https://i.pravatar.cc/150?u=${currentUser.uid}`
 


### PR DESCRIPTION
I’m not sure whether this is necessary, since the Nuxt version in this example is ^3.12.3 and mine is ^4.4.2. However, my linter showed a warning, so I went ahead and fixed it.